### PR TITLE
Feat/remove dependancy on default on reducers

### DIFF
--- a/src/handleModule.js
+++ b/src/handleModule.js
@@ -4,12 +4,12 @@ export default function handleModule(moduleFile) {
   const { reducers, initialState } = moduleFile;
   let missingPart = '';
   if (!initialState) missingPart = 'initial state';
-  if (reducers && !reducers.default) {
+  if (!reducers) {
     missingPart += missingPart ? 'nor ' : '';
     missingPart += 'default reducers';
   }
   if (missingPart) {
-    console.warn(`You are attempting to connect a module that doesn export any ${missingPart}.`);
+    console.warn(`You are attempting to connect a module that doesn't export any ${missingPart}.`);
   }
-  return handleActions(reducers.default || reducers, initialState || {});
+  return handleActions(reducers, initialState || {});
 }


### PR DESCRIPTION
Remove the dependancy on reducers.default inside the `handleModule` logic.